### PR TITLE
Quote about string to handle colon

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Question via Jaeger Community Support (online chat)
     url: https://cloud-native.slack.com/archives/CGG7NFUJ3.
-    about: Please ask and answer questions here for faster response. If you don't have an account, signup at: https://slack.cncf.io/.
+    about: "Please ask and answer questions here for faster response. If you don't have an account, signup at: https://slack.cncf.io/."
   - name: Question via GitHub Discussions (similar to Stack Overflow)
     url: https://github.com/jaegertracing/jaeger/discussions
     about: Please ask and answer questions here for async response.


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Resolves: https://github.com/jaegertracing/.github/pull/1#discussion_r637480984 and relates to jaegertracing/jaeger#2974.

## Short description of the changes
- yaml interprets `:` as the beginning of a map or list, so we need to quote the string to escape the colon in the URL.
