### PR TITLE
Add instruction to use feature branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ Before creating a pull request, please make sure:
   - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
 - You added unit tests for the new functionality
 - You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
+- You created the PR from a feature branch, and not master
 -->
 
 ## Which problem is this PR solving?


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

## Which problem is this PR solving?
- Contributors often find their PR builds fail because they created it off their `master` branch.

## Short description of the changes
- Provide instructions to create the PR of a feature branch.
