### PR TITLE
Automatically tag triage for new bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Create a report to help us improve
 title: "[Bug]: "
-labels: ["bug"]
+labels: bug, triage
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Modify the issue template to add trage tag in addition to the bug tag.

## Description of the changes
Add the triage tag in addition to the bug tag

## How was this change tested?
Not tested

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits